### PR TITLE
WIP on pipeline inheritance

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -13,6 +13,45 @@ add to architecture
 
 ========================================================================================
 
+WIP on pipeline inheritance
+
+we are trying to do this should do this:
+- on a non-inherited pipeline, unnamed pipelines are NOT combined (or should they be? I think no)
+- on a non-inherited pipeline, named pipelines ARE combined
+- for inheritance, the first unnamed pipeline is combined. (subsequent unnamed pipelines are not combined). -- too complicated??? need to decide.
+- you can also append to named pipelines by declaring a pipeline of the same name on the child. -- this is the same as non-inherited
+- if the final result is that there is a single pipeline, it is hoisted to become the root pipeline. this can be either done with a setter, a private setter (probably best), or a redefinition of the task (probably not)
+- update readme accordingly (there is a WIP section)
+
+==================================
+
+      # Evaluate stored pipeline blocks on instance task with instance context
+      blocks = self.class._pipeline_definition_blocks
+      single_unnamed = (blocks.size == 1 && blocks.first[:name].nil?)
+
+      blocks.each do |entry|
+        name = entry[:name]
+        opts = entry[:options]
+
+        if single_unnamed
+          # Single unnamed pipeline: add stages directly to root_pipeline
+          pipeline_dsl = PipelineDSL.new(@_minigun_task.root_pipeline, self)
+          pipeline_dsl.instance_eval(&entry[:block])
+        else
+          # Multiple pipelines OR named pipeline: create a PipelineStage
+          # Generate name if not provided (for unnamed blocks)
+          name ||= :"_pipeline_#{SecureRandom.uuid}"
+          @_minigun_task.define_pipeline(name, opts) do |pipeline|
+            pipeline_dsl = PipelineDSL.new(pipeline, self)
+            pipeline_dsl.instance_eval(&entry[:block])
+          end
+        end
+      end
+
+instead of this, hoist the pipleine
+
+===============================
+
 Support Cross-Pipeline Routing?
 - use stage identifiers instead of names?
 - Yes! We'd need to:

--- a/examples/49_nested_pipeline_variations.rb
+++ b/examples/49_nested_pipeline_variations.rb
@@ -1,0 +1,93 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../lib/minigun'
+
+# Comprehensive test of named and unnamed pipelines at various nesting levels
+class NestedPipelineVariations
+  include Minigun::DSL
+
+  attr_accessor :results
+
+  def initialize
+    @results = []
+    @mutex = Mutex.new
+  end
+
+  # Top-level WITH name
+  pipeline :top_level_with_name do
+    producer :source_named do |output|
+      output << "from_named_top"
+    end
+
+    # Nested WITHOUT name
+    pipeline do
+      processor :process_in_unnamed_nested do |item, output|
+        output << "#{item}_processed"
+      end
+    end
+
+    consumer :collect_named do |item|
+      @mutex.synchronize { @results << item }
+    end
+  end
+
+  # Top-level WITHOUT name (default pipeline)
+  pipeline do
+    producer :source_default do |output|
+      output << "from_default_top"
+    end
+
+    # Nested WITH name
+    pipeline :nested_with_name do
+      processor :process_in_named_nested do |item, output|
+        output << "#{item}_in_named"
+      end
+
+      # Nested 2 levels deep WITH name
+      pipeline :doubly_nested_with_name do
+        processor :deep_process_named do |item, output|
+          output << "#{item}_deep_named"
+        end
+      end
+    end
+
+    # Nested 2 levels deep WITHOUT name
+    pipeline do
+      processor :level_1_unnamed do |item, output|
+        output << "#{item}_level1"
+      end
+
+      pipeline do
+        processor :level_2_unnamed do |item, output|
+          output << "#{item}_level2"
+        end
+      end
+    end
+
+    consumer :collect_default do |item|
+      @mutex.synchronize { @results << item }
+    end
+  end
+end
+
+if __FILE__ == $0
+  puts "=== Nested Pipeline Variations ===\n\n"
+
+  example = NestedPipelineVariations.new
+  example.run
+
+  puts "\n=== Results ===\n"
+  puts "Results: #{example.results.sort.inspect}"
+
+  # We should have results from both top-level pipelines
+  has_named = example.results.any? { |r| r.include?("from_named_top") }
+  has_default = example.results.any? { |r| r.include?("from_default_top") }
+
+  puts "Has results from named top-level: #{has_named}"
+  puts "Has results from default top-level: #{has_default}"
+
+  success = has_named && has_default
+  puts success ? "✓ Success!" : "✗ Failed"
+end
+

--- a/examples/50_pipeline_inheritance.rb
+++ b/examples/50_pipeline_inheritance.rb
@@ -1,0 +1,218 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../lib/minigun'
+
+# Pipeline Inheritance Example
+# Demonstrates how child classes can extend parent pipelines
+
+# === Example 1: Extending unnamed (default) pipeline ===
+class BaseTask
+  include Minigun::DSL
+
+  attr_accessor :results
+
+  def initialize
+    @results = []
+  end
+
+  pipeline do
+    producer :source do |output|
+      puts "[Base] Producing: 1, 2, 3"
+      [1, 2, 3].each { |n| output << n }
+    end
+
+    processor :double do |n, output|
+      result = n * 2
+      puts "[Base] Double: #{n} -> #{result}"
+      output << result
+    end
+
+    consumer :collect do |n|
+      puts "[Base] Collect: #{n}"
+      @results << n
+    end
+  end
+end
+
+class ExtendedTask < BaseTask
+  # This pipeline block is MERGED with parent's unnamed pipeline
+  # because it's the first unnamed pipeline
+  pipeline do
+    processor :triple do |n, output|
+      result = n * 3
+      puts "[Child] Triple: #{n} -> #{result}"
+      output << result
+    end
+
+    # Reroute to insert triple between double and collect
+    reroute_stage :double, to: :triple
+    reroute_stage :triple, to: :collect
+  end
+end
+
+class SkipStageTask < BaseTask
+  # This also merges with parent's unnamed pipeline
+  pipeline do
+    # Skip the double stage entirely
+    reroute_stage :source, to: :collect
+  end
+end
+
+# === Example 2: Extending named pipelines ===
+class NamedPipelineBase
+  include Minigun::DSL
+
+  attr_accessor :results_a, :results_b
+
+  def initialize
+    @results_a = []
+    @results_b = []
+  end
+
+  pipeline :pipeline_a do
+    producer :source_a do |output|
+      puts "[Base A] Producing: 10, 20"
+      [10, 20].each { |n| output << n }
+    end
+
+    consumer :collect_a do |n|
+      puts "[Base A] Collect: #{n}"
+      @results_a << n
+    end
+  end
+
+  pipeline :pipeline_b do
+    producer :source_b do |output|
+      puts "[Base B] Producing: 100, 200"
+      [100, 200].each { |n| output << n }
+    end
+
+    consumer :collect_b do |n|
+      puts "[Base B] Collect: #{n}"
+      @results_b << n
+    end
+  end
+end
+
+class ExtendedNamedPipeline < NamedPipelineBase
+  # Extend pipeline_a by declaring it again
+  pipeline :pipeline_a do
+    processor :process_a do |n, output|
+      result = n + 5
+      puts "[Child A] Process: #{n} -> #{result}"
+      output << result
+    end
+
+    reroute_stage :source_a, to: :process_a
+    reroute_stage :process_a, to: :collect_a
+  end
+
+  # pipeline_b is inherited as-is (not extended)
+end
+
+# === Example 3: Multiple unnamed pipelines (only first is merged) ===
+class MultipleUnnamedBase
+  include Minigun::DSL
+
+  attr_accessor :results
+
+  def initialize
+    @results = []
+  end
+
+  pipeline do
+    producer :main_source do |output|
+      puts "[Main] Producing: A, B"
+      ['A', 'B'].each { |c| output << c }
+    end
+
+    consumer :main_collect do |c|
+      puts "[Main] Collect: #{c}"
+      @results << c
+    end
+  end
+end
+
+class MultipleUnnamedChild < MultipleUnnamedBase
+  # First unnamed pipeline: MERGES with parent
+  pipeline do
+    processor :uppercase do |c, output|
+      result = c.upcase
+      puts "[Child] Uppercase: #{c} -> #{result}"
+      output << result
+    end
+
+    reroute_stage :main_source, to: :uppercase
+    reroute_stage :uppercase, to: :main_collect
+  end
+
+  # Second unnamed pipeline: ISOLATED (does not merge)
+  pipeline do
+    producer :extra_source do |output|
+      puts "[Extra] Producing: X, Y"
+      ['X', 'Y'].each { |c| output << c }
+    end
+
+    consumer :extra_collect do |c|
+      puts "[Extra] Collect: #{c}"
+      @results << "extra_#{c}"
+    end
+  end
+end
+
+if __FILE__ == $0
+  puts "=== Pipeline Inheritance Example ===\n\n"
+
+  puts "--- Example 1a: Base Task ---"
+  base = BaseTask.new
+  base.run
+  puts "Results: #{base.results.inspect}"
+  puts "Expected: [2, 4, 6] (doubled)"
+  puts base.results == [2, 4, 6] ? "✓ Pass" : "✗ Fail"
+
+  puts "\n--- Example 1b: Extended Task (insert triple stage) ---"
+  extended = ExtendedTask.new
+  extended.run
+  puts "Results: #{extended.results.inspect}"
+  puts "Expected: [6, 12, 18] (double then triple)"
+  puts extended.results == [6, 12, 18] ? "✓ Pass" : "✗ Fail"
+
+  puts "\n--- Example 1c: Skip Stage Task ---"
+  skip = SkipStageTask.new
+  skip.run
+  puts "Results: #{skip.results.inspect}"
+  puts "Expected: [1, 2, 3] (skip double)"
+  puts skip.results == [1, 2, 3] ? "✓ Pass" : "✗ Fail"
+
+  puts "\n--- Example 2a: Named Pipeline Base ---"
+  named_base = NamedPipelineBase.new
+  named_base.run
+  puts "Results A: #{named_base.results_a.inspect}"
+  puts "Results B: #{named_base.results_b.inspect}"
+  puts "Expected A: [10, 20], Expected B: [100, 200]"
+  puts (named_base.results_a == [10, 20] && named_base.results_b == [100, 200]) ? "✓ Pass" : "✗ Fail"
+
+  puts "\n--- Example 2b: Extended Named Pipeline (only pipeline_a extended) ---"
+  extended_named = ExtendedNamedPipeline.new
+  extended_named.run
+  puts "Results A: #{extended_named.results_a.inspect}"
+  puts "Results B: #{extended_named.results_b.inspect}"
+  puts "Expected A: [15, 25] (processed), Expected B: [100, 200] (unchanged)"
+  puts (extended_named.results_a == [15, 25] && extended_named.results_b == [100, 200]) ? "✓ Pass" : "✗ Fail"
+
+  puts "\n--- Example 3: Multiple Unnamed Pipelines ---"
+  multi = MultipleUnnamedChild.new
+  multi.run
+  puts "Results: #{multi.results.sort.inspect}"
+  puts "Expected: ['A', 'B', 'extra_X', 'extra_Y'] (first merged, second isolated)"
+  puts multi.results.sort == ['A', 'B', 'extra_X', 'extra_Y'].sort ? "✓ Pass" : "✗ Fail"
+
+  puts "\n=== Key Concepts ==="
+  puts "• First unnamed pipeline in child: MERGES with parent's unnamed pipeline"
+  puts "• Named pipeline in child with same name: EXTENDS parent's named pipeline"
+  puts "• Subsequent unnamed pipelines: ISOLATED (don't merge)"
+  puts "• Allows natural inheritance: children can add stages and reroute parent's stages"
+  puts "\n✓ Pipeline inheritance complete!"
+end
+

--- a/spec/integration/examples_spec.rb
+++ b/spec/integration/examples_spec.rb
@@ -740,6 +740,26 @@ RSpec.describe 'Examples Integration' do
     end
   end
 
+  describe '49_nested_pipeline_variations.rb' do
+    it 'supports named and unnamed pipelines at various nesting levels' do
+      require_relative '../../examples/49_nested_pipeline_variations'
+
+      example = NestedPipelineVariations.new
+      example.run
+
+      # Should have results from both top-level pipelines
+      expect(example.results).not_to be_empty
+
+      # Check for results from named top-level pipeline
+      has_named_results = example.results.any? { |r| r.to_s.include?("from_named_top") }
+      expect(has_named_results).to be(true), "Expected results from named top-level pipeline"
+
+      # Check for results from default (unnamed) top-level pipeline
+      has_default_results = example.results.any? { |r| r.to_s.include?("from_default_top") }
+      expect(has_default_results).to be(true), "Expected results from default top-level pipeline"
+    end
+  end
+
   describe '46_deduplicator_stage.rb' do
     it 'demonstrates simple value deduplication' do
       load File.expand_path('../../examples/46_deduplicator_stage.rb', __dir__)
@@ -814,6 +834,41 @@ RSpec.describe 'Examples Integration' do
       ensure
         $stdout = original_stdout
       end
+    end
+  end
+
+  describe '50_pipeline_inheritance.rb' do
+    it 'demonstrates pipeline inheritance and merging' do
+      require_relative '../../examples/50_pipeline_inheritance'
+
+      # Example 1: Unnamed pipeline inheritance
+      base = BaseTask.new
+      base.run
+      expect(base.results).to eq([2, 4, 6])
+
+      extended = ExtendedTask.new
+      extended.run
+      expect(extended.results).to eq([6, 12, 18])
+
+      skip = SkipStageTask.new
+      skip.run
+      expect(skip.results).to eq([1, 2, 3])
+
+      # Example 2: Named pipeline extension
+      named_base = NamedPipelineBase.new
+      named_base.run
+      expect(named_base.results_a).to eq([10, 20])
+      expect(named_base.results_b).to eq([100, 200])
+
+      extended_named = ExtendedNamedPipeline.new
+      extended_named.run
+      expect(extended_named.results_a).to eq([15, 25])
+      expect(extended_named.results_b).to eq([100, 200])
+
+      # Example 3: Multiple unnamed pipelines
+      multi = MultipleUnnamedChild.new
+      multi.run
+      expect(multi.results.sort).to eq(['A', 'B', 'extra_X', 'extra_Y'].sort)
     end
   end
 end


### PR DESCRIPTION
we are trying to do this:
- on a non-inherited pipeline, unnamed pipelines are NOT combined (or should they be? I think no)
- on a non-inherited pipeline, named pipelines ARE combined
- for inheritance, the first unnamed pipeline is combined. (subsequent unnamed pipelines are not combined). -- too complicated??? need to decide.
- you can also append to named pipelines by declaring a pipeline of the same name on the child. -- this is the same as non-inherited
- if the final result is that there is a single pipeline, it is hoisted to become the root pipeline. this can be either done with a setter, a private setter (probably best), or a redefinition of the task (probably not)
- update readme accordingly (there is a WIP section)