### PR TITLE
Dynamic routing WIP

### DIFF
--- a/YIELD_SYNTAX_IMPLEMENTATION.md
+++ b/YIELD_SYNTAX_IMPLEMENTATION.md
@@ -93,17 +93,18 @@ This makes the `output` parameter completely optional while maintaining backward
 
 - **`examples/00_quick_start_yield.rb`**: Basic yield syntax demonstration
 - **`examples/63_yield_with_classes.rb`**: Comprehensive example with routing
+- **`examples/69_yield_routing.rb`**: Dynamic routing with yield and to: parameter
 
 ### 5. Tests
 
 - **`spec/unit/yield_syntax_spec.rb`**: Unit tests covering all arity combinations
 - **`spec/integration/examples_spec.rb`**: Integration tests for yield examples
 
-### 6. Known Limitations
+### 6. Dynamic Routing Support
 
-**Dynamic Routing Issue**: Stages that only receive dynamically-routed items (via `yield(item, to: :stage_name)`) don't have static upstream connections in the DAG, so they don't wait for input and exit immediately. This is a general limitation with Minigun's current dynamic routing implementation, not specific to the yield syntax.
+**Dynamic Routing**: Stages can receive items exclusively through dynamic routing (via `yield(item, to: :stage_name)` or `output.to(:stage_name) << item`) without requiring static upstream connections in the DAG. The system automatically discovers dynamic sources when `EndOfSource` signals arrive and properly handles stage lifecycle.
 
-**Workaround**: Ensure stages receiving dynamic routes also have at least one static upstream connection in the DAG.
+This enables flexible routing patterns where stages are targeted based on runtime decisions without needing predefined DAG connections.
 
 ### 7. Backward Compatibility
 

--- a/examples/69_yield_routing.rb
+++ b/examples/69_yield_routing.rb
@@ -1,0 +1,103 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../lib/minigun'
+
+# Custom router stage that uses yield with to: parameter for dynamic routing
+class ParityRouter < Minigun::ConsumerStage
+  def call(item)
+    if item.even?
+      # Route even numbers to even_processor
+      yield(item, to: :even_processor)
+    else
+      # Route odd numbers to odd_processor
+      yield(item, to: :odd_processor)
+    end
+  end
+end
+
+# Custom processor for even numbers
+class EvenProcessor < Minigun::ConsumerStage
+  def call(item)
+    # Double even numbers
+    yield(item * 2)
+  end
+end
+
+# Custom processor for odd numbers
+class OddProcessor < Minigun::ConsumerStage
+  def call(item)
+    # Triple odd numbers
+    yield(item * 3)
+  end
+end
+
+# Example demonstrating yield with dynamic routing
+class YieldRoutingExample
+  include Minigun::DSL
+
+  attr_reader :even_results, :odd_results
+
+  def initialize
+    @even_results = []
+    @odd_results = []
+    @mutex = Mutex.new
+  end
+
+  pipeline do
+    # Generate numbers 0-9
+    producer :generate do |output|
+      10.times { |i| output << i }
+    end
+
+    # Route numbers based on parity using yield(item, to: :stage_name)
+    custom_stage(ParityRouter, :router, from: :generate)
+
+    # Process even and odd numbers separately
+    custom_stage(EvenProcessor, :even_processor)
+    custom_stage(OddProcessor, :odd_processor)
+
+    # Collect results from each processor
+    consumer :collect_even, from: :even_processor do |item|
+      @mutex.synchronize { @even_results << item }
+    end
+
+    consumer :collect_odd, from: :odd_processor do |item|
+      @mutex.synchronize { @odd_results << item }
+    end
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  puts "=== Yield with Dynamic Routing Example ===\n\n"
+  puts 'This example demonstrates using yield with the to: parameter'
+  puts 'to dynamically route items to specific stages by name.'
+  puts ''
+  puts 'The router inspects each number and routes it to either'
+  puts 'the even_processor or odd_processor based on parity.'
+  puts ''
+  puts "Key feature: yield(item, to: :stage_name)\n\n"
+
+  example = YieldRoutingExample.new
+  example.run
+
+  puts "=== Results ===\n"
+  puts "Input numbers: 0-9"
+  puts "Even numbers (doubled): #{example.even_results.sort.join(', ')}"
+  puts "Odd numbers (tripled): #{example.odd_results.sort.join(', ')}"
+
+  expected_even = [0, 4, 8, 12, 16]  # 0*2, 2*2, 4*2, 6*2, 8*2
+  expected_odd = [3, 9, 15, 21, 27]  # 1*3, 3*3, 5*3, 7*3, 9*3
+
+  puts ''
+  puts "Even results correct: #{example.even_results.sort == expected_even ? '✓' : '✗'}"
+  puts "Odd results correct: #{example.odd_results.sort == expected_odd ? '✓' : '✗'}"
+  puts "\n✓ Yield routing example complete!"
+  puts ''
+  puts 'Benefits of yield with dynamic routing:'
+  puts '  • Natural Ruby syntax for routing logic'
+  puts '  • Type-safe stage name references'
+  puts '  • Clear intent in routing decisions'
+  puts '  • Stages with only dynamic inputs work correctly'
+end
+

--- a/spec/integration/examples_spec.rb
+++ b/spec/integration/examples_spec.rb
@@ -1323,7 +1323,19 @@ RSpec.describe 'Examples Integration' do
       example.run
 
       expect(example.even_results.sort).to eq([0, 4, 8, 12, 16])
-      # NOTE: odd_results may be empty due to routing issue, but that's tracked separately
+      expect(example.odd_results.sort).to eq([3, 9, 15, 21, 27])
+    end
+  end
+
+  describe '69_yield_routing.rb' do
+    it 'demonstrates yield with dynamic routing using to: parameter' do
+      load File.expand_path('../../examples/69_yield_routing.rb', __dir__)
+
+      example = YieldRoutingExample.new
+      example.run
+
+      expect(example.even_results.sort).to eq([0, 4, 8, 12, 16])
+      expect(example.odd_results.sort).to eq([3, 9, 15, 21, 27])
     end
   end
 

--- a/spec/unit/yield_syntax_spec.rb
+++ b/spec/unit/yield_syntax_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe 'Yield Syntax Support' do
   describe 'yield with routing' do
     # Known limitation: stages with only dynamically-routed inputs don't wait for input
     # This is tracked separately as a general dynamic routing limitation
-    it 'supports yield(item, to: :stage_name) - known limitation with dynamic routing', skip: 'Known limitation with dynamic routing' do
+    it 'supports yield(item, to: :stage_name)' do
       router_stage = Class.new(Minigun::ConsumerStage) do
         def call(item, _output)
           if item.even?
@@ -261,8 +261,8 @@ RSpec.describe 'Yield Syntax Support' do
       end
 
       example_class.new.run
-      expect(even_results.sort).to eq([0, 4, 8])
-      expect(odd_results.sort).to eq([3, 9, 15])
+      expect(even_results.sort).to eq([0, 4, 8])  # 0*2, 2*2, 4*2
+      expect(odd_results.sort).to eq([3, 9])  # 1*3, 3*3
     end
   end
 


### PR DESCRIPTION
~~This PR started as a fix for yield_syntax_spec.rb but uncovered an issue in the process related to dynamic routing.~~

~~The core problem is that disconnected stages -- e.g. consumers with no upstream--will automatically shutdown instantly based on logic we added. See worker.rb line 60 (# If no upstream sources, this stage is disconnected)~~

~~If we remove this logic, these disconnected stages will never shut-down, unless they get a dynamic producer to connect to them (or their pipeline sends and send of stage?)~~

~~The solution is something like (A) allowing stages to be declared as disconnected: true, and (B) adding various keep-alive options for stages so they have a change to receive dynamic inputs before shutting down. A 3rd option (C) is to send Nonce signal (StageConnected) and/or KeepAlive signal to the stage initially, to declare the dynamic linkage. That might require some keepalive.~~

~~The yield example should be refactored to use connected stages~~

The issue here was solved with the `await` option on disconnected stages. I've changed the PR to just add the tests.